### PR TITLE
Numpy/Pandas Py2 incompatibility

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -56,11 +56,17 @@ setup(
     # simple. Or you can use find_packages().
     packages=find_packages(exclude=['contrib', 'docs', 'tests*']),
 
+    setup_requires=['numpy'],
     # List run-time dependencies here.  These will be installed by pip when your
     # project is installed. For an analysis of "install_requires" vs pip's
     # requirements files see:
     # https://packaging.python.org/en/latest/technical.html#install-requires-vs-requirements-files
-    install_requires=[],
+    install_requires=[
+        'numpy',
+	'pandas==0.20.3',
+	'pdfminer==20131113',
+	'xlrd',
+    ],
 
     # If there are data files included in your packages that need to be
     # installed, specify them here.  If using Python 2.6 or less, then these

--- a/setup.py
+++ b/setup.py
@@ -56,15 +56,15 @@ setup(
     # simple. Or you can use find_packages().
     packages=find_packages(exclude=['contrib', 'docs', 'tests*']),
 
-    setup_requires=['numpy'],
     # List run-time dependencies here.  These will be installed by pip when your
     # project is installed. For an analysis of "install_requires" vs pip's
     # requirements files see:
     # https://packaging.python.org/en/latest/technical.html#install-requires-vs-requirements-files
     install_requires=[
-	'pandas',
-	'pdfminer==20131113',
-	'xlrd',
+        'xlrd',
+        'pandas==0.20.3',
+        'python-docx',
+        'pdfminer==20131113'
     ],
 
     # If there are data files included in your packages that need to be

--- a/setup.py
+++ b/setup.py
@@ -62,8 +62,7 @@ setup(
     # requirements files see:
     # https://packaging.python.org/en/latest/technical.html#install-requires-vs-requirements-files
     install_requires=[
-        'numpy',
-	'pandas==0.20.3',
+	'pandas',
 	'pdfminer==20131113',
 	'xlrd',
     ],


### PR DESCRIPTION
I removed `Numpy` as a dependency. That solves problem in `docker build`, but `pip install numpy` is needed in `Dockerfile` before installing `cprvalidation`